### PR TITLE
Update search.cpp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1179,7 +1179,8 @@ moves_loop: // When in check and at SpNode search starts from here
     // Check for an instant draw or if the maximum ply has been reached
     if (pos.is_draw() || ss->ply > MAX_PLY)
     {
-        if (pos.total_piece_count() <= TBCardinality)
+        if (pos.total_piece_count() <= TBCardinality
+        && ((ss-1)->currentMove != MOVE_NULL && (ss-1)->currentMove != MOVE_NONE))
         {
             int found, v = Tablebases::probe_wdl(const_cast<Position&>(pos), &found);
             Value value;
@@ -1223,7 +1224,8 @@ moves_loop: // When in check and at SpNode search starts from here
         return ttValue;
     }
 
-    if (pos.total_piece_count() <= TBCardinality)
+    if (pos.total_piece_count() <= TBCardinality
+        && ((ss-1)->currentMove != MOVE_NULL && (ss-1)->currentMove != MOVE_NONE))
     {
         int found, v = Tablebases::probe_wdl(const_cast<Position&>(pos), &found);
         Value value;


### PR DESCRIPTION
I would like to propose this test in fishtest
this is bench with change (5 binaries, 5 bench each one as MCostalba suggested)
 sudo nice -n -20 taskset -c 0 syzygy bench 256 1 21 >/dev/null
Total time (ms) : 163871
Nodes searched  : 233017798
Nodes/second    : 1421958

This is original syzygy1/stockfish (best  binary from 5 compiles, 5 bench ...)
sudo nice -n -20 taskset -c 0 syzygy-master bench 256 1 21 >/dev/null
Total time (ms) : 182664
Nodes searched  : 254261586
Nodes/second    : 1391963

From my tests with cutechess 15+0.05 i get a very close result but i cannot say if it works on 40.000 games, so it would be nice to try fishtest.
I use 5men syzygy tablebase only, the 5 men database is complete (145 file).
To balance the if added in qsearch, i removed some if from search() i apologize if this is not correct with the fork policy.
Thanks you. 

P.S.

This is perft 7 with source modified
sudo nice -n -20 taskset -c 0 syzygy perft 7 >/dev/null 

Position: 1/1

Perft 7 leaf nodes: 3195901860
# 

Total time (ms) : 23436
Nodes searched  : 3195901860
Nodes/second    : 136367206

This is from original syzygy1/stockfish
sudo nice -n -20 taskset -c 0 syzygy-master perft 7 >/dev/null

Position: 1/1

Perft 7 leaf nodes: 3195901860
# 

Total time (ms) : 23171
Nodes searched  : 3195901860
Nodes/second    : 137926799
