### PR TITLE
Add Syzygybase support to PGO build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -35,7 +35,8 @@ endif
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
-PGOBENCH = ./$(EXE) bench 32 1 1 default time
+PGOBENCH = ( echo setoption value SyzygyPath value "$(SYZYGY-PATH)" ; \
+	echo bench 32 1 1 default time ) | ./$(EXE) 
 
 ### Object files
 OBJS = benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o \
@@ -320,7 +321,7 @@ help:
 	@echo ""
 	@echo "To compile stockfish, type: "
 	@echo ""
-	@echo "make target ARCH=arch [COMP=comp]"
+	@echo "make target ARCH=arch [COMP=comp] [SYZYGY-PATH="Path to Syzygybases for PGO build"]"
 	@echo ""
 	@echo "Supported targets:"
 	@echo ""


### PR DESCRIPTION
Currently PGO build isn't using Syzygybases. This patch allows PGO build capable compiler to optimize the part of Stockfish that deals with Syzygybases.
